### PR TITLE
Fix heap buffer overflow

### DIFF
--- a/src/heap_buffer_overflow.cpp
+++ b/src/heap_buffer_overflow.cpp
@@ -5,8 +5,9 @@
 void heap_buffer_overflow(int a, int b, std::string c) {
   if (a > 100 && b < 100 && c == "FUZZING") {
           // Trigger a heap buffer overflow
-          char *s = (char *)malloc(1);
+          char *s = (char *)malloc(100);
           strcpy(s, "too long");
           printf("%s\n", s);
+          free(s);
   }
 }


### PR DESCRIPTION
Heap buffer overflow fixed, stack buffer overflow assessed.

Based on the assessment and ticket creation and the deduplication of the finding, we will only get a pipeline warning rather than full blocking. 