### PR TITLE
Add missing header

### DIFF
--- a/src/heap_buffer_overflow.h
+++ b/src/heap_buffer_overflow.h
@@ -1,3 +1,4 @@
 #include <string>
+#include <cstdint>
 
 bool heap_buffer_overflow(const uint8_t *data, size_t data_size);


### PR DESCRIPTION
Fixes build to fail with:

    [ 20%] Building CXX object CMakeFiles/heap_buffer_overflow.dir/src/heap_buffer_overflow.cpp.o
    In file included from /home/adrian/projects/c-cpp-demo/src/heap_buffer_overflow.cpp:1:
    /home/adrian/projects/c-cpp-demo/src/heap_buffer_overflow.h:3:33: error: unknown type name 'uint8_t'
        3 | bool heap_buffer_overflow(const uint8_t *data, size_t data_size);